### PR TITLE
Deal with ISBNv13 instead of ISBN10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # barcode-rust [![Build Status](https://travis-ci.org/patrickod/barcode-rust.svg?branch=master)](https://travis-ci.org/patrickod/barcode-rust)
 
-Tiny binary to read scancodes from a Inateck BCST-20 barcode scanner which I intend to use to catalogue the book collection at [Noisebridge](https://noisebridge.net)
+Tiny binary to read scancodes from a Inateck BCST-20 barcode scanner which I
+intend to use to catalogue the book collection at
+[Noisebridge](https://noisebridge.net)
 
 This project is mostly an experiment with rust and c libraries
+
+## What
+
+`scanner` is a small utility that can be used with a USB barcode scanner
+to help the process of cataloging books at Noisebridge. It specifically
+addresses two issues with using USB barcode scanners for this purpose
+
+  a) The USB scanners emulate keyboards and so write out to STDIN. For
+     systems with multiple input devices this is cumbersome
+  b) We only want the consumer of this program's output to deal with
+     valid ISBN codes to ingest them into the catalogue.
+
+`scanner` uses
+[libevdev](https://wiki.freedesktop.org/www/Software/libevdev/), a
+wrapper around evdevices in Linux to "claim" the input device created by
+the USB scanner such that its input events aren't consumable by other
+programs accepting input from stdin at the same time. It filters parse
+it's input for valid ISBNv13 barcodes. which it then writes to stdout

--- a/src/events.rs
+++ b/src/events.rs
@@ -471,7 +471,7 @@ impl KeyEvent {
             KeyEvent::KEY_SEMICOLON => ";",
             KeyEvent::KEY_SLASH => "/",
             KeyEvent::KEY_TAB => "\t",
-            KeyEvent::KEY_END => "\n",
+            KeyEvent::KEY_ENTER => "\n",
             _ => "",
         }
     }

--- a/src/isbn.rs
+++ b/src/isbn.rs
@@ -1,35 +1,22 @@
-pub fn is_isbn(upc: &[u8]) -> bool {
-    // Is the UPC code from "Bookland"
-    // https://en.wikipedia.org/wiki/Bookland
-    &upc[0..3] == &[9,7,8]
-}
-
-#[test]
-fn test_is_isbn() {
-    assert!(is_isbn(&[9,7,8]));
-    assert!(!is_isbn(&[1,2,3]));
-}
-
-pub fn upc_to_isbn(upc: &[u8]) -> Vec<u8> {
-    let isbn = &upc[3..12];
-    let mut sum: u8 = 0;
-
-    for i in 0..9 {
-        let j = &isbn[i];
-        sum = sum + (10u8 - i as u8) * *j;
+pub fn isbn_13_valid(isbn: &[u8]) -> bool {
+    // Must at least be 13 characters
+    if isbn.len() != 13 {
+        return false;
     }
-    sum = sum % 11;
-    sum = 11 - sum;
 
-    // Create the result Vec and
-    // push the checksum bit
-    let mut r = Vec::from(isbn);
-    r.push(sum);
+    let checksum = isbn[0..12].iter().enumerate().map(|(i, &n)| {
+        if i % 2 == 0 {
+            n
+        } else {
+            3 * n
+        }
+    }).fold(0, |acc, n| acc + n) % 10;
 
-    return r;
+    return checksum == *(isbn.last().unwrap());
 }
 
 #[test]
-fn test_upc_to_isbn() {
-    assert!(upc_to_isbn(&[9,7,8,0,5,9,6,0,0,4,1,0,1]) == &[0,5,9,6,0,0,4,1,0,9])
+fn test_isbn_13_valid() {
+    assert!(isbn_13_valid(&[9,7,8,0,7,6,5,3,1,2,8,1,5]));
+    assert!(!isbn_13_valid(&[9,7,8,0,7,6,5,3,1,2,8,1,6]));
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,24 +1,40 @@
-#![allow(unused_must_use)]
-use events::KeyEvent;
 use libevdev::InputEvent;
 use std::io::stdout;
 use std::io::Write;
 
+use isbn::isbn_13_valid;
+use events::KeyEvent;
+
 use num::FromPrimitive;
 
 pub fn parse_event(ev: &InputEvent, buf: &mut Vec<u8> ) {
-    // Only deal with KEY_DOWN events
-    if ev.event_type == 1 && ev.value == 1 {
-        let key = KeyEvent::from_u16(ev.code).unwrap();
-        if !key.to_char().is_empty() {
-            buf.push(key.to_char().parse::<u8>().unwrap());
+    if !should_parse_event(ev) {
+        return;
+    }
+
+    let key = KeyEvent::from_u16(ev.code).unwrap();
+    if !key.to_char().is_empty() {
+        match key.to_char().parse::<u8>() {
+            Ok(v) => buf.push(v),
+            Err(_) => ()
         }
     }
+
     // Flush out the buffer if we've taken a newline
-    if buf.len() > 0 && *buf.last().unwrap() == KeyEvent::KEY_END as u8 {
+    if buf.len() > 0 && key == KeyEvent::KEY_ENTER {
         let mut stdout = stdout();
-        stdout.write(buf);
+
+        if isbn_13_valid(buf) {
+            for &c in buf.iter() {
+                stdout.write(c.to_string().as_bytes());
+            }
+            stdout.write(key.to_char().as_bytes());
+        }
         stdout.flush();
         buf.clear();
     }
+}
+
+fn should_parse_event(ev: &InputEvent) -> bool {
+    return ev.event_type == 1 && ev.value == 1;
 }


### PR DESCRIPTION
Write actual check function which recomputes the check bit and compares
to see if the thing we're passed is a valid looking ISBN.

Only writes out valid ISBNv13 codes to stdout, while allowing other
barcodes to be scanned without writing out.
